### PR TITLE
Adding stopWatchReset()

### DIFF
--- a/src/main/java/com/learnjava/parallelstreams/ParallelStreamPerformance.java
+++ b/src/main/java/com/learnjava/parallelstreams/ParallelStreamPerformance.java
@@ -19,6 +19,7 @@ public class ParallelStreamPerformance {
         int sum = intStream
                 .sum();
         timeTaken();
+        stopWatchReset();
         return sum;
     }
 
@@ -34,6 +35,7 @@ public class ParallelStreamPerformance {
                 .mapToInt(Integer::intValue) // unboxing
                 .sum();
         timeTaken();
+        stopWatchReset();
         return sum;
     }
 
@@ -51,6 +53,7 @@ public class ParallelStreamPerformance {
                 .reduce(0, Integer::sum);
 
         timeTaken();
+        stopWatchReset();
         return sum;
     }
 

--- a/src/main/java/com/learnjava/parallelstreams/ParallelStreamPerformance.java
+++ b/src/main/java/com/learnjava/parallelstreams/ParallelStreamPerformance.java
@@ -4,8 +4,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static com.learnjava.util.CommonUtil.startTimer;
-import static com.learnjava.util.CommonUtil.timeTaken;
+import static com.learnjava.util.CommonUtil.*;
 
 public class ParallelStreamPerformance {
 


### PR DESCRIPTION
Adding `stopWatchReset()` after every timeTaken() call in `ParallelStreamPerformance.java`. This is to resolve the following issue.
[5#issue-981631195](https://github.com/dilipsundarraj1/parallel-asynchronous-using-java/issues/5#issue-981631195)
Kindly review the PR.